### PR TITLE
Improve Deployment steps with Docker

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,11 +56,10 @@ Open the app [here](localhost:8000)
 
 Ensure that docker is running.
 
-If you use docker in your workflow, there is a Dockerfile in the root directory for you. Simply run:
+If you use docker in your workflow, there is a Dockerfile (that you can build an image from) in the root directory for you. `docker-compose` is the easiest way to get up and running. Simply run:
 
 ```bash
-$ docker build -t [image-name] .
-$ docker run [image-name]
+$ docker-compose up
 ```
 
 Open the app [here](localhost:8000)

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - 8000:8000


### PR DESCRIPTION
#### What does this PR do?
Update docs README for GH pages
Adds `docker-compose.yml`
#### Description of Task to be completed?
The former steps:
```
$ docker build -t [image-name] .
$ docker run [image-name]
```
lacked the `-p` (flag) for mapping ports hence the developer could not view `vue-django` in [localhost](http://0.0.0.0:8000).
#### How should this be manually tested?
Go through steps at https://ndagistanley.github.io/vue-django/#deploy-with-docker